### PR TITLE
Fix warnings when not using ARC

### DIFF
--- a/peertalk/PTChannel.h
+++ b/peertalk/PTChannel.h
@@ -19,7 +19,7 @@
 @property (strong) id<PTChannelDelegate> delegate;
 
 // Communication protocol. Must not be nil.
-@property PTProtocol *protocol;
+@property (nonatomic, retain) PTProtocol *protocol;
 
 // YES if this channel is a listening server
 @property (readonly) BOOL isListening;

--- a/peertalk/PTChannel.m
+++ b/peertalk/PTChannel.m
@@ -94,6 +94,10 @@ static const uint8_t kUserInfoKey;
 - (void)dealloc {
   if (dispatchObj_.channel) dispatch_release(dispatchObj_.channel);
   else if (dispatchObj_.source) dispatch_release(dispatchObj_.source);
+  
+#if !__has_feature(objc_arc)
+  [super dealloc];
+#endif
 }
 
 
@@ -615,6 +619,10 @@ static const uint8_t kUserInfoKey;
   if (dispatchData_) dispatch_release(dispatchData_);
   data_ = NULL;
   length_ = 0;
+  
+#if !__has_feature(objc_arc)
+  [super dealloc];
+#endif
 }
 
 #pragma mark - NSObject

--- a/peertalk/PTProtocol.m
+++ b/peertalk/PTProtocol.m
@@ -83,6 +83,10 @@ static void _release_queue_local_protocol(void *objcobj) {
   if (queue_) {
     dispatch_release(queue_);
   }
+  
+#if !__has_feature(objc_arc)
+  [super dealloc];
+#endif
 }
 
 - (dispatch_queue_t)queue {
@@ -302,6 +306,10 @@ static void _release_queue_local_protocol(void *objcobj) {
 }
 - (void)dealloc {
   if (dispatchData_) dispatch_release(dispatchData_);
+  
+#if !__has_feature(objc_arc)
+  [super dealloc];
+#endif
 }
 @end
 

--- a/peertalk/PTUSBHub.m
+++ b/peertalk/PTUSBHub.m
@@ -301,6 +301,10 @@ static NSString *kPlistPacketTypeConnect = @"Connect";
     dispatch_release(channel_);
     channel_ = nil;
   }
+  
+#if !__has_feature(objc_arc)
+  [super dealloc];
+#endif
 }
 
 


### PR DESCRIPTION
Check if ARC is disabled and if so, call [super dealloc] when needed.
