### PR TITLE
Fix pointer precedence  NSString * const is a constant pointer)

### DIFF
--- a/peertalk/PTProtocol.h
+++ b/peertalk/PTProtocol.h
@@ -22,7 +22,7 @@ static const uint32_t PTFrameNoTag = 0;
 static const uint32_t PTFrameTypeEndOfStream = 0;
 
 // NSError domain
-FOUNDATION_EXPORT NSString const *PTProtocolErrorDomain;
+FOUNDATION_EXPORT NSString * const PTProtocolErrorDomain;
 
 
 @interface PTProtocol : NSObject

--- a/peertalk/PTProtocol.m
+++ b/peertalk/PTProtocol.m
@@ -4,7 +4,7 @@
 
 static const uint32_t PTProtocolVersion1 = 1;
 
-NSString const *PTProtocolErrorDomain = @"PTProtocolError";
+NSString * const PTProtocolErrorDomain = @"PTProtocolError";
 
 // This is what we send as the header for each frame.
 typedef struct _PTFrame {

--- a/peertalk/PTUSBHub.h
+++ b/peertalk/PTUSBHub.h
@@ -17,7 +17,7 @@
 //    };
 //  }
 //
-FOUNDATION_EXPORT NSString const *PTUSBDeviceDidAttachNotification;
+FOUNDATION_EXPORT NSString * const PTUSBDeviceDidAttachNotification;
 
 // PTUSBDeviceDidDetachNotification
 // Posted when a device has been detached.
@@ -27,10 +27,10 @@ FOUNDATION_EXPORT NSString const *PTUSBDeviceDidAttachNotification;
 //    MessageType = Detached;
 //  }
 //
-FOUNDATION_EXPORT NSString const *PTUSBDeviceDidDetachNotification;
+FOUNDATION_EXPORT NSString * const PTUSBDeviceDidDetachNotification;
 
 // NSError domain
-FOUNDATION_EXPORT NSString const *PTUSBHubErrorDomain;
+FOUNDATION_EXPORT NSString * const PTUSBHubErrorDomain;
 
 // Error codes returned with NSError.code for NSError domain PTUSBHubErrorDomain
 typedef enum {

--- a/peertalk/PTUSBHub.m
+++ b/peertalk/PTUSBHub.m
@@ -7,7 +7,7 @@
 #include <sys/un.h>
 #include <err.h>
 
-NSString const *PTUSBHubErrorDomain = @"PTUSBHubError";
+NSString * const PTUSBHubErrorDomain = @"PTUSBHubError";
 
 typedef uint32_t USBMuxPacketType;
 enum {
@@ -98,8 +98,8 @@ static void usbmux_packet_free(usbmux_packet_t *upacket) {
 }
 
 
-NSString const *PTUSBDeviceDidAttachNotification = @"PTUSBDeviceDidAttachNotification";
-NSString const *PTUSBDeviceDidDetachNotification = @"PTUSBDeviceDidDetachNotification";
+NSString * const PTUSBDeviceDidAttachNotification = @"PTUSBDeviceDidAttachNotification";
+NSString * const PTUSBDeviceDidDetachNotification = @"PTUSBDeviceDidDetachNotification";
 
 static NSString *kPlistPacketTypeListen = @"Listen";
 static NSString *kPlistPacketTypeConnect = @"Connect";


### PR DESCRIPTION
Fix pointer precedence. NSString const * is a pointer to constant string and we have a constant pointer to a string. Its fix compiler warnings too