### PR TITLE
Remove compiler warning

### DIFF
--- a/peertalk/PTProtocol.m
+++ b/peertalk/PTProtocol.m
@@ -350,6 +350,9 @@ static void _release_queue_local_protocol(void *objcobj) {
 
 @implementation NSData (PTProtocol)
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-getter-return-value"
+
 - (dispatch_data_t)createReferencingDispatchData {
   // Note: The queue is used to submit the destructor. Since we only perform an
   // atomic release of self, it doesn't really matter which queue is used, thus
@@ -359,6 +362,8 @@ static void _release_queue_local_protocol(void *objcobj) {
     [self length];
   });
 }
+
+#pragma clang diagnostic pop
 
 + (NSData *)dataWithContentsOfDispatchData:(dispatch_data_t)data {
   if (!data) {

--- a/peertalk/PTUSBHub.m
+++ b/peertalk/PTUSBHub.m
@@ -589,6 +589,8 @@ static NSString *kPlistPacketTypeConnect = @"Connect";
 #endif
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-getter-return-value"
 
 - (void)sendData:(NSData*)data callback:(void(^)(NSError*))callback {
   dispatch_data_t ddata = dispatch_data_create((const void*)data.bytes, data.length, queue_, ^{
@@ -598,6 +600,7 @@ static NSString *kPlistPacketTypeConnect = @"Connect";
   [self sendDispatchData:ddata callback:callback];
 }
 
+#pragma clang diagnostic pop
 
 - (void)readFromOffset:(off_t)offset length:(size_t)length callback:(void(^)(NSError *error, dispatch_data_t data))callback {
   dispatch_io_read(channel_, offset, length, queue_, ^(bool done, dispatch_data_t data, int _errno) {


### PR DESCRIPTION
Hi! I couldn't come up better way to retain self for blocks, so I added #pragma directive to remove clang warnings. 