### PR TITLE
Fix logic that enables pre-ARC behavior

### DIFF
--- a/peertalk/PTPrivate.h
+++ b/peertalk/PTPrivate.h
@@ -3,10 +3,10 @@
 #define PT_DISPATCH_RETAIN_RELEASE 1
 #endif
 
-#if PT_DISPATCH_RETAIN_RELEASE
 #define PT_PRECISE_LIFETIME
 #define PT_PRECISE_LIFETIME_UNUSED
-#else
+
+#if defined(PT_DISPATCH_RETAIN_RELEASE) && PT_DISPATCH_RETAIN_RELEASE
 #define PT_PRECISE_LIFETIME __attribute__((objc_precise_lifetime))
 #define PT_PRECISE_LIFETIME_UNUSED __attribute__((objc_precise_lifetime, unused))
 #endif


### PR DESCRIPTION
This logic, as far as I can tell, was flawed and was doing the opposite of what the writer intended. It wasn't disabling ARC pre iOS6.0 and it was causing the following compiler errors. That being said, I didn't test this on a project that is supporting anything before iOS6.0 and therefore this might be entirely wrong.

<img width="483" alt="screen shot 2015-07-17 at 6 14 28 pm" src="https://cloud.githubusercontent.com/assets/160298/8758265/db0b59a2-2caf-11e5-9c5e-83b58471e648.png">
