### PR TITLE
Add PeerTalk.podspec file to repository root

### DIFF
--- a/PeerTalk.podspec
+++ b/PeerTalk.podspec
@@ -1,0 +1,17 @@
+{
+  "name": "PeerTalk",
+  "version": "0.0.1",
+  "summary": "iOS and OS X Cocoa library for communicating over USB and TCP.",
+  "description": "                    PeerTalk is a iOS and OS X Cocoa library for communicating over USB and TCP.\n\n                    Highlights:\n\n                    * Provides you with USB device attach/detach events and attached device's info\n                    * Can connect to TCP services on supported attached devices (e.g. an iPhone), bridging the communication over USB transport\n                    * Offers a higher-level API (PTChannel and PTProtocol) for convenient implementations.\n                    * Tested and designed for libdispatch (aka Grand Central Dispatch).\n",
+  "homepage": "http://rsms.me/peertalk/",
+  "license": "MIT",
+  "authors": {
+    "Rasmus Andersson": "rasmus@notion.se"
+  },
+  "source": {
+    "git": "https://github.com/rsms/peertalk.git",
+    "commit": "a454694e873dcb07faba2982633efbfe2779cf5b"
+  },
+  "source_files": "peertalk/*.{h,m}",
+  "requires_arc": true
+}

--- a/PeerTalk.podspec
+++ b/PeerTalk.podspec
@@ -1,17 +1,14 @@
-{
-  "name": "PeerTalk",
-  "version": "0.0.1",
-  "summary": "iOS and OS X Cocoa library for communicating over USB and TCP.",
-  "description": "                    PeerTalk is a iOS and OS X Cocoa library for communicating over USB and TCP.\n\n                    Highlights:\n\n                    * Provides you with USB device attach/detach events and attached device's info\n                    * Can connect to TCP services on supported attached devices (e.g. an iPhone), bridging the communication over USB transport\n                    * Offers a higher-level API (PTChannel and PTProtocol) for convenient implementations.\n                    * Tested and designed for libdispatch (aka Grand Central Dispatch).\n",
-  "homepage": "http://rsms.me/peertalk/",
-  "license": "MIT",
-  "authors": {
-    "Rasmus Andersson": "rasmus@notion.se"
-  },
-  "source": {
-    "git": "https://github.com/rsms/peertalk.git",
-    "commit": "a454694e873dcb07faba2982633efbfe2779cf5b"
-  },
-  "source_files": "peertalk/*.{h,m}",
-  "requires_arc": true
-}
+Pod::Spec.new do |spec|
+    spec.name     = 'PeerTalk'
+    spec.version  = '0.0.1'
+    spec.license  = { :type => 'MIT' }
+    spec.homepage = 'http://rsms.me/peertalk/'
+    spec.authors  = { 'Rasmus Andersson' => 'rasmus@notion.se' }
+    spec.summary  = 'iOS and OS X Cocoa library for communicating over USB and TCP.'
+
+    spec.source   = { :git => "https://github.com/rsms/PeerTalk.git", :commit => 'b9e59e7c55de34361a7c5ea38f1767c53b4534b8' }
+    spec.source_files = 'peertalk/*.{h,m}'
+    spec.requires_arc = true
+
+   spec.description = "                    PeerTalk is a iOS and OS X Cocoa library for communicating over USB and TCP.\n\n                    Highlights:\n\n                    * Provides you with USB device attach/detach events and attached device's info\n                    * Can connect to TCP services on supported attached devices (e.g. an iPhone), bridging the communication over USB transport\n                    * Offers a higher-level API (PTChannel and PTProtocol) for convenient implementations.\n                    * Tested and designed for libdispatch (aka Grand Central Dispatch).\n"
+end


### PR DESCRIPTION
The podspec that is part of cocoapods is referencing a very old version of PeerTalk. I wanted to see if the tip of rsms/peertalk fixed the compiler warning I was receiving, which is partially does. In order to do this I needed to specify a commit in my applications `Podfile`, AND to do that PeerTalk needed a `podspec` in it's root directory.

This patch [enables](https://guides.cocoapods.org/using/the-podfile.html#from-a-podspec-in-the-root-of-a-library-repo) the following to be used in a `Podfile`, which is useful for development.

```ruby
pod 'PeerTalk', :git => 'https://github.com/rsms/peertalk.git', :commit => 'b9e59e7c55de34361a7c5ea38f1767c53b4534b8'
```

or

```ruby
pod 'PeerTalk', :git => 'https://github.com/rsms/peertalk.git', :branch => 'master'
```

The version should probably be bumped. This patch is barebones to just get things functioning as `pod` expects.