### PR TITLE
Make PTUSBChannel work correctly in a bundle-less (e.g. cli) app

### DIFF
--- a/peertalk/PTUSBHub.m
+++ b/peertalk/PTUSBHub.m
@@ -276,7 +276,7 @@ static NSString *kPlistPacketTypeConnect = @"Connect";
               bundleVersion, @"ClientVersionString",
               nil];
   } else {
-    packet = [NSDictionary dictionaryWithObjectsAndKeys:@"Listen", @"MessageType", nil];
+    packet = [NSDictionary dictionaryWithObjectsAndKeys:messageType, @"MessageType", nil];
   }
   
   if (payload) {


### PR DESCRIPTION
Without this fix, I get repeated disconnected/connected events in a pure command-line app (no bundle, no Info.plist). Bundling the command line tool as a full-blown Mac .app with an Info.plist fixes it, but that's not ideal. I believe the real fix is in this patch, which has the code path that deals with the absence of a bundle mimic the functionality other code path.