### PR TITLE
Fix crash in -[PTProtocol readPayloadOfSize:overChannel:]

### DIFF
--- a/peertalk/PTProtocol.m
+++ b/peertalk/PTProtocol.m
@@ -307,7 +307,7 @@ static void _release_queue_local_protocol(void *objcobj) {
 - (void)readAndDiscardDataOfSize:(size_t)size overChannel:(dispatch_io_t)channel callback:(void(^)(NSError*, BOOL))callback {
   dispatch_io_read(channel, 0, size, queue_, ^(bool done, dispatch_data_t data, int error) {
     if (done && callback) {
-      size_t dataSize = dispatch_data_get_size(data);
+      size_t dataSize = data ? dispatch_data_get_size(data) : 0;
       callback(error == 0 ? nil : [[NSError alloc] initWithDomain:NSPOSIXErrorDomain code:error userInfo:nil], dataSize == 0);
     }
   });


### PR DESCRIPTION
`data` can be NULL when a connection is closed or lost, this change simply checks for this before calling `dispatch_data_get_size()`