### PR TITLE
address issue where dispatch_io_read cal be called with a data argume…

### DIFF
--- a/peertalk/PTProtocol.m
+++ b/peertalk/PTProtocol.m
@@ -198,7 +198,7 @@ static void _release_queue_local_protocol(void *objcobj) {
 - (void)readPayloadOfSize:(size_t)payloadSize overChannel:(dispatch_io_t)channel callback:(void(^)(NSError *error, dispatch_data_t contiguousData, const uint8_t *buffer, size_t bufferSize))callback {
   __block dispatch_data_t allData = NULL;
   dispatch_io_read(channel, 0, payloadSize, queue_, ^(bool done, dispatch_data_t data, int error) {
-    size_t dataSize = dispatch_data_get_size(data);
+    size_t dataSize = data ? dispatch_data_get_size(data) : 0;
     
     if (dataSize) {
       if (!allData) {


### PR DESCRIPTION
Hello. I ran into a crash in the block passed to dispatch_io_read and from what I could see it seemed to be caused by data being set to nil. This is my attempt to address that crash by setting dataSize to 0. This seemed to be a random one time situation and I have not been able to reproduce the issue since.