### PR TITLE
Prevent starting processes indefinitely.

### DIFF
--- a/peertalk/PTUSBHub.m
+++ b/peertalk/PTUSBHub.m
@@ -352,6 +352,7 @@ static NSString *kPlistPacketTypeConnect = @"Connect";
   socklen_t socklen = sizeof(addr);
   if (connect(fd, (struct sockaddr*)&addr, socklen) == -1) {
     if (error) *error = [[NSError alloc] initWithDomain:NSPOSIXErrorDomain code:errno userInfo:nil];
+    close(fd);
     return NO;
   }
   


### PR DESCRIPTION
Close the socket to prevent the system from starting infinite processes.

We encountered an issue where this function would attempt to open ~15-20 sockets every second without ever closing them.
This was reproduced consistently by simply connecting an iPhone and waiting for the infinite number of processes to eventually reach the maximum limit available on our machine (Macbook pro)
At this point, all apps would cease the function. It was no longer possible to even restart the machine from the menu. A manual power cycle was required. 